### PR TITLE
Eye Spy a fix!

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs = -Xmx3G
 # No daemon
 org.gradle.daemon = false
 
-modVersion = 1.1
+modVersion = 1.2-beta0
 modId = betterstrongholds
 modGroup = com.yungnickyoung.minecraft.betterstrongholds
 modFileName = BetterStrongholds

--- a/src/main/java/com/yungnickyoung/minecraft/betterstrongholds/BetterStrongholds.java
+++ b/src/main/java/com/yungnickyoung/minecraft/betterstrongholds/BetterStrongholds.java
@@ -3,6 +3,7 @@ package com.yungnickyoung.minecraft.betterstrongholds;
 import com.google.common.collect.Lists;
 import com.yungnickyoung.minecraft.betterstrongholds.config.BSConfig;
 import com.yungnickyoung.minecraft.betterstrongholds.init.BSModConfig;
+import com.yungnickyoung.minecraft.betterstrongholds.init.BSModCriterions;
 import com.yungnickyoung.minecraft.betterstrongholds.init.BSModProcessors;
 import com.yungnickyoung.minecraft.betterstrongholds.init.BSModStructures;
 import net.minecraftforge.fml.common.Mod;
@@ -36,6 +37,7 @@ public class BetterStrongholds {
 
     private void init() {
         BSModProcessors.init();
+        BSModCriterions.init();
         BSModStructures.init();
         BSModConfig.init();
     }

--- a/src/main/java/com/yungnickyoung/minecraft/betterstrongholds/criteria/SafeStructureLocatePredicate.java
+++ b/src/main/java/com/yungnickyoung/minecraft/betterstrongholds/criteria/SafeStructureLocatePredicate.java
@@ -1,0 +1,50 @@
+package com.yungnickyoung.minecraft.betterstrongholds.criteria;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.minecraft.util.JSONUtils;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.gen.feature.structure.Structure;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import javax.annotation.Nullable;
+
+public class SafeStructureLocatePredicate {
+
+    @Nullable
+    private final Structure<?> feature;
+
+    public SafeStructureLocatePredicate(@Nullable Structure<?> feature) {
+        this.feature = feature;
+    }
+
+    public boolean test(ServerWorld world, double x, double y, double z) {
+        return this.test(world, (float)x, (float)y, (float)z);
+    }
+
+    public boolean test(ServerWorld world, float x, float y, float z) {
+        BlockPos blockpos = new BlockPos(x, y, z);
+        return this.feature != null && world.isBlockPresent(blockpos) && world.func_241112_a_().getStructureStart(blockpos, true, this.feature).isValid();
+    }
+
+    public JsonElement serialize() {
+        JsonObject jsonobject = new JsonObject();
+        if (this.feature != null) {
+            jsonobject.addProperty("feature", this.feature.getStructureName());
+        }
+        return jsonobject;
+    }
+
+    public static SafeStructureLocatePredicate deserialize(@Nullable JsonElement element) {
+        if (element != null && !element.isJsonNull()) {
+            JsonObject jsonobject = JSONUtils.getJsonObject(element, "location");
+            Structure<?> structure = jsonobject.has("feature") ? ForgeRegistries.STRUCTURE_FEATURES.getValue(new ResourceLocation(JSONUtils.getString(jsonobject, "feature"))) : null;
+
+            return new SafeStructureLocatePredicate(structure);
+        } else {
+            return new SafeStructureLocatePredicate(null);
+        }
+    }
+}

--- a/src/main/java/com/yungnickyoung/minecraft/betterstrongholds/criteria/SafeStructureLocatePredicate.java
+++ b/src/main/java/com/yungnickyoung/minecraft/betterstrongholds/criteria/SafeStructureLocatePredicate.java
@@ -12,7 +12,6 @@ import net.minecraftforge.registries.ForgeRegistries;
 import javax.annotation.Nullable;
 
 public class SafeStructureLocatePredicate {
-
     @Nullable
     private final Structure<?> feature;
 

--- a/src/main/java/com/yungnickyoung/minecraft/betterstrongholds/criteria/SafeStructurePositionTrigger.java
+++ b/src/main/java/com/yungnickyoung/minecraft/betterstrongholds/criteria/SafeStructurePositionTrigger.java
@@ -2,6 +2,7 @@ package com.yungnickyoung.minecraft.betterstrongholds.criteria;
 
 import com.google.gson.JsonObject;
 import com.yungnickyoung.minecraft.betterstrongholds.init.BSModCriterions;
+import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.advancements.criterion.AbstractCriterionTrigger;
 import net.minecraft.advancements.criterion.CriterionInstance;
@@ -14,6 +15,9 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.event.TickEvent;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@MethodsReturnNonnullByDefault
 public class SafeStructurePositionTrigger extends AbstractCriterionTrigger<SafeStructurePositionTrigger.Instance> {
     private final ResourceLocation id;
 
@@ -33,6 +37,7 @@ public class SafeStructurePositionTrigger extends AbstractCriterionTrigger<SafeS
     }
 
     @Override
+    @ParametersAreNonnullByDefault
     public SafeStructurePositionTrigger.Instance deserializeTrigger(JsonObject json, EntityPredicate.AndPredicate entityPredicate, ConditionArrayParser conditionsParser) {
         JsonObject jsonobject = JSONUtils.getJsonObject(json, "location", json);
         SafeStructureLocatePredicate safeStructureLocatePredicate = SafeStructureLocatePredicate.deserialize(jsonobject);
@@ -60,6 +65,7 @@ public class SafeStructurePositionTrigger extends AbstractCriterionTrigger<SafeS
         }
 
         @Override
+        @ParametersAreNonnullByDefault
         public JsonObject serialize(ConditionArraySerializer conditions) {
             JsonObject jsonobject = super.serialize(conditions);
             jsonobject.add("location", this.location.serialize());

--- a/src/main/java/com/yungnickyoung/minecraft/betterstrongholds/criteria/SafeStructurePositionTrigger.java
+++ b/src/main/java/com/yungnickyoung/minecraft/betterstrongholds/criteria/SafeStructurePositionTrigger.java
@@ -1,0 +1,69 @@
+package com.yungnickyoung.minecraft.betterstrongholds.criteria;
+
+import com.google.gson.JsonObject;
+import com.yungnickyoung.minecraft.betterstrongholds.init.BSModCriterions;
+import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.advancements.criterion.AbstractCriterionTrigger;
+import net.minecraft.advancements.criterion.CriterionInstance;
+import net.minecraft.advancements.criterion.EntityPredicate;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.loot.ConditionArrayParser;
+import net.minecraft.loot.ConditionArraySerializer;
+import net.minecraft.util.JSONUtils;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.event.TickEvent;
+
+public class SafeStructurePositionTrigger extends AbstractCriterionTrigger<SafeStructurePositionTrigger.Instance> {
+    private final ResourceLocation id;
+
+    public SafeStructurePositionTrigger(ResourceLocation id) {
+        this.id = id;
+    }
+
+    @Override
+    public ResourceLocation getId() {
+        return this.id;
+    }
+
+    public static void playerTick(TickEvent.PlayerTickEvent event) {
+        if (event.player instanceof ServerPlayerEntity && event.player.ticksExisted % 20 == 0) {
+            BSModCriterions.SAFE_STRUCTURE_POSITION_TRIGGER.trigger((ServerPlayerEntity) event.player);
+        }
+    }
+
+    @Override
+    public SafeStructurePositionTrigger.Instance deserializeTrigger(JsonObject json, EntityPredicate.AndPredicate entityPredicate, ConditionArrayParser conditionsParser) {
+        JsonObject jsonobject = JSONUtils.getJsonObject(json, "location", json);
+        SafeStructureLocatePredicate safeStructureLocatePredicate = SafeStructureLocatePredicate.deserialize(jsonobject);
+        return new SafeStructurePositionTrigger.Instance(this.id, entityPredicate, safeStructureLocatePredicate);
+    }
+
+    public void trigger(ServerPlayerEntity player) {
+        this.triggerListeners(player, (instance) -> instance.test(player.getServerWorld(), player.getPosX(), player.getPosY(), player.getPosZ()));
+    }
+
+    public static class Instance extends CriterionInstance {
+        private final SafeStructureLocatePredicate location;
+
+        public Instance(ResourceLocation id, EntityPredicate.AndPredicate player, SafeStructureLocatePredicate location) {
+            super(id, player);
+            this.location = location;
+        }
+
+        public static SafeStructurePositionTrigger.Instance forLocation(SafeStructureLocatePredicate location) {
+            return new SafeStructurePositionTrigger.Instance(CriteriaTriggers.LOCATION.getId(), EntityPredicate.AndPredicate.ANY_AND, location);
+        }
+
+        public boolean test(ServerWorld world, double x, double y, double z) {
+            return this.location.test(world, x, y, z);
+        }
+
+        @Override
+        public JsonObject serialize(ConditionArraySerializer conditions) {
+            JsonObject jsonobject = super.serialize(conditions);
+            jsonobject.add("location", this.location.serialize());
+            return jsonobject;
+        }
+    }
+}

--- a/src/main/java/com/yungnickyoung/minecraft/betterstrongholds/init/BSModCriterions.java
+++ b/src/main/java/com/yungnickyoung/minecraft/betterstrongholds/init/BSModCriterions.java
@@ -1,0 +1,25 @@
+package com.yungnickyoung.minecraft.betterstrongholds.init;
+
+import com.yungnickyoung.minecraft.betterstrongholds.BetterStrongholds;
+import com.yungnickyoung.minecraft.betterstrongholds.criteria.SafeStructurePositionTrigger;
+import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+
+public class BSModCriterions {
+    public static final SafeStructurePositionTrigger SAFE_STRUCTURE_POSITION_TRIGGER = new SafeStructurePositionTrigger(new ResourceLocation(BetterStrongholds.MOD_ID, "structure_location"));
+
+    public static void init() {
+        FMLJavaModLoadingContext.get().getModEventBus().addListener(BSModCriterions::commonSetup);
+
+        MinecraftForge.EVENT_BUS.addListener(SafeStructurePositionTrigger::playerTick);
+    }
+
+    private static void commonSetup(FMLCommonSetupEvent event) {
+        event.enqueueWork(() -> {
+            CriteriaTriggers.register(SAFE_STRUCTURE_POSITION_TRIGGER);
+        });
+    }
+}

--- a/src/main/java/com/yungnickyoung/minecraft/betterstrongholds/init/BSModCriterions.java
+++ b/src/main/java/com/yungnickyoung/minecraft/betterstrongholds/init/BSModCriterions.java
@@ -13,7 +13,6 @@ public class BSModCriterions {
 
     public static void init() {
         FMLJavaModLoadingContext.get().getModEventBus().addListener(BSModCriterions::commonSetup);
-
         MinecraftForge.EVENT_BUS.addListener(SafeStructurePositionTrigger::playerTick);
     }
 

--- a/src/main/resources/data/minecraft/advancements/story/follow_ender_eye.json
+++ b/src/main/resources/data/minecraft/advancements/story/follow_ender_eye.json
@@ -1,0 +1,47 @@
+{
+  "parent": "minecraft:story/enter_the_nether",
+  "display": {
+    "icon": {
+      "item": "minecraft:ender_eye"
+    },
+    "title": {
+      "translate": "advancements.story.follow_ender_eye.title"
+    },
+    "description": {
+      "translate": "advancements.story.follow_ender_eye.description"
+    },
+    "frame": "task",
+    "show_toast": true,
+    "announce_to_chat": true,
+    "hidden": false
+  },
+  "criteria": {
+    "in_stronghold": {
+      "trigger": "minecraft:location",
+      "conditions": {
+        "location": {
+          "feature": "stronghold"
+        }
+      }
+    },
+    "in_stronghold_betterstrongholds": {
+      "trigger": "betterstrongholds:structure_location",
+      "conditions": {
+        "feature": "betterstrongholds:stronghold"
+      }
+    },
+    "in_castle_endrem": {
+      "trigger": "betterstrongholds:structure_location",
+      "conditions": {
+        "feature": "endrem:end_castle"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "in_stronghold",
+      "in_stronghold_betterstrongholds",
+      "in_castle_endrem"
+    ]
+  ]
+}

--- a/src/main/resources/data/minecraft/advancements/story/follow_ender_eye.json
+++ b/src/main/resources/data/minecraft/advancements/story/follow_ender_eye.json
@@ -30,10 +30,10 @@
         "feature": "betterstrongholds:stronghold"
       }
     },
-    "in_castle_endrem": {
+    "in_gate_endrem": {
       "trigger": "betterstrongholds:structure_location",
       "conditions": {
-        "feature": "endrem:end_castle"
+        "feature": "endrem:end_gate"
       }
     }
   },
@@ -41,7 +41,7 @@
     [
       "in_stronghold",
       "in_stronghold_betterstrongholds",
-      "in_castle_endrem"
+      "in_gate_endrem"
     ]
   ]
 }


### PR DESCRIPTION
made eye spy now work with Better End strongholds and with End Remastered stronghold replacement structure if they are on. To do this, I made a custom criteria and predicate that is structure safe. if the structure passed in doesnt exist in the structure registry, it makes the predicate return false instead of instantly granting the advancement. The feature field for the custom predicate will use the structure registry instead of the bimap to resolve what structure to find